### PR TITLE
feat: multi-profile support — run multiple Hermes Agent instances on one machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,68 @@ hermes-agent-cloud destroy --cloud aws
 
 ---
 
+## Multi-Profile Support
+
+Run **multiple isolated Hermes Agent instances** on the same machine — each with its own API keys, config, port, and systemd service.
+
+### Use Cases
+
+- Separate **work** and **personal** profiles with different API keys
+- Run **different LLM providers** side-by-side (e.g. OpenRouter vs Anthropic)
+- Isolate **projects** that need different agent configurations
+
+### Profile Commands
+
+```bash
+# Create a new profile (prompts for API keys)
+hermes-agent-cloud profile create work
+hermes-agent-cloud profile create personal
+
+# List all profiles and their ports
+hermes-agent-cloud profile list
+
+# Switch the active profile
+hermes-agent-cloud profile use work
+
+# Show details of a profile
+hermes-agent-cloud profile show work
+
+# Remove a profile
+hermes-agent-cloud profile remove work
+```
+
+### Port Allocation
+
+Each profile gets an automatically assigned port pair:
+
+| Profile  | Web Dashboard | API Gateway |
+|----------|---------------|-------------|
+| `default` | `9119`       | `8080`      |
+| 1st extra | `9120`       | `8081`      |
+| 2nd extra | `9121`       | `8082`      |
+| …         | …            | …           |
+
+### Profile Storage
+
+```
+~/.hermes-profiles/
+├── default/          # backward-compatible with v1.x
+│   ├── .env          # API keys (chmod 600)
+│   └── config.yaml
+├── work/
+│   ├── .env
+│   └── config.yaml
+└── personal/
+    ├── .env
+    └── config.yaml
+```
+
+Each profile runs as its own **systemd service** (`hermes-default`, `hermes-work`, `hermes-personal`), so they start independently on reboot.
+
+> **Backward compatibility:** Existing single-instance deployments continue to work unchanged — they are automatically treated as the `default` profile.
+
+---
+
 ## Run the Website Locally
 
 ```bash

--- a/cli/hermes-deploy
+++ b/cli/hermes-deploy
@@ -50,6 +50,8 @@ source "${HERMES_DEPLOY_DIR}/lib/aws.sh"
 source "${HERMES_DEPLOY_DIR}/lib/azure.sh"
 # shellcheck source=lib/gcp.sh
 source "${HERMES_DEPLOY_DIR}/lib/gcp.sh"
+# shellcheck source=lib/profile.sh
+source "${HERMES_DEPLOY_DIR}/lib/profile.sh"
 
 # ─── Globals ────────────────────────────────────────────────────────────────
 CLOUD=""
@@ -88,6 +90,7 @@ cmd_help() {
   printf "  %-12s %s\n" "logs"    "Stream live Hermes gateway logs"
   printf "  %-12s %s\n" "secrets" "Update API keys in the cloud vault"
   printf "  %-12s %s\n" "destroy" "Tear down all deployed resources"
+  printf "  %-12s %s\n" "profile" "Manage named profiles (multi-instance)"
   printf "  %-12s %s\n" "version" "Print version"
   echo ""
   gum style --foreground 212 --bold "OPTIONS"
@@ -219,6 +222,7 @@ main() {
     logs)    cmd_logs    ;;
     secrets) cmd_secrets ;;
     destroy) cmd_destroy ;;
+    profile) cmd_profile "${REMAINING_ARGS[@]:-}" ;;
     version) cmd_version ;;
     help)    cmd_help    ;;
     *)

--- a/cli/lib/profile.sh
+++ b/cli/lib/profile.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# profile.sh — Multi-profile management for Hermes Agent Cloud
+#
+# Each profile is an isolated Hermes Agent instance with its own:
+#   - API keys  : ~/.hermes-profiles/<name>/.env
+#   - Config    : ~/.hermes-profiles/<name>/config.yaml
+#   - Port pair : web (9119+N) and API gateway (8080+N)
+#   - systemd   : hermes-<name>.service
+#
+# The "default" profile is backward-compatible with v1.x single-instance deploys.
+
+PROFILES_DIR="${HOME}/.hermes-profiles"
+ACTIVE_PROFILE_FILE="${HERMES_DEPLOY_HOME}/active_profile"
+
+# ── Port allocation ──────────────────────────────────────────────────────────
+# default → web=9119, api=8080
+# Profile slot N (0-based) → web=9119+N, api=8080+N
+profile_web_port()  { local slot="${1:-0}"; echo $(( 9119 + slot )); }
+profile_api_port()  { local slot="${1:-0}"; echo $(( 8080 + slot )); }
+
+profile_slot() {
+  local name="$1"
+  [[ "$name" == "default" ]] && { echo 0; return; }
+  local slots_file="${HERMES_DEPLOY_HOME}/profile_slots"
+  touch "$slots_file"
+  # Find existing slot
+  local existing
+  existing=$(grep "^${name}=" "$slots_file" 2>/dev/null | cut -d= -f2 || true)
+  if [[ -n "$existing" ]]; then
+    echo "$existing"
+    return
+  fi
+  # Allocate next available slot (1-based for non-default)
+  local max=0
+  while IFS='=' read -r _ slot; do
+    (( slot > max )) && max=$slot
+  done < "$slots_file"
+  local next=$(( max + 1 ))
+  echo "${name}=${next}" >> "$slots_file"
+  echo "$next"
+}
+
+# ── Active profile ───────────────────────────────────────────────────────────
+profile_get_active() {
+  if [[ -f "$ACTIVE_PROFILE_FILE" ]]; then
+    cat "$ACTIVE_PROFILE_FILE"
+  else
+    echo "default"
+  fi
+}
+
+profile_set_active() {
+  local name="$1"
+  mkdir -p "$HERMES_DEPLOY_HOME"
+  echo "$name" > "$ACTIVE_PROFILE_FILE"
+}
+
+# ── Profile directory ────────────────────────────────────────────────────────
+profile_dir() {
+  local name="${1:-default}"
+  echo "${PROFILES_DIR}/${name}"
+}
+
+profile_exists() {
+  local name="$1"
+  [[ -d "${PROFILES_DIR}/${name}" ]]
+}
+
+profile_list_names() {
+  if [[ ! -d "$PROFILES_DIR" ]]; then
+    echo "default"
+    return
+  fi
+  ls -1 "$PROFILES_DIR" 2>/dev/null || echo "default"
+}
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+
+cmd_profile() {
+  local subcmd="${1:-}"
+  shift || true
+
+  case "$subcmd" in
+    list)    profile_cmd_list   "$@" ;;
+    use)     profile_cmd_use    "$@" ;;
+    create)  profile_cmd_create "$@" ;;
+    remove)  profile_cmd_remove "$@" ;;
+    show)    profile_cmd_show   "$@" ;;
+    ""|help) profile_cmd_help        ;;
+    *)
+      error "Unknown profile subcommand: $subcmd"
+      profile_cmd_help
+      exit 1
+      ;;
+  esac
+}
+
+profile_cmd_help() {
+  echo ""
+  gum style --foreground 212 --bold "USAGE"
+  echo "  hermes-agent-cloud profile <subcommand>"
+  echo ""
+  gum style --foreground 212 --bold "SUBCOMMANDS"
+  printf "  %-10s %s\n" "list"   "List all profiles and their status"
+  printf "  %-10s %s\n" "use"    "Switch the active profile"
+  printf "  %-10s %s\n" "create" "Create a new named profile (prompts for API keys)"
+  printf "  %-10s %s\n" "remove" "Delete a profile and its config"
+  printf "  %-10s %s\n" "show"   "Show details of a profile"
+  echo ""
+  gum style --foreground 212 --bold "EXAMPLES"
+  echo "  hermes-agent-cloud profile list"
+  echo "  hermes-agent-cloud profile create work"
+  echo "  hermes-agent-cloud profile use work"
+  echo "  hermes-agent-cloud profile remove work"
+  echo ""
+}
+
+profile_cmd_list() {
+  local active
+  active=$(profile_get_active)
+
+  echo ""
+  gum style --bold --foreground 212 "Hermes Agent Profiles"
+  echo ""
+  printf "  %-16s %-8s %-12s %-12s %s\n" "NAME" "STATUS" "WEB PORT" "API PORT" "CONFIG"
+  printf "  %-16s %-8s %-12s %-12s %s\n" "────────────────" "────────" "────────────" "────────────" "──────"
+
+  local found=false
+  while IFS= read -r name; do
+    found=true
+    local slot
+    slot=$(profile_slot "$name")
+    local web_port api_port
+    web_port=$(profile_web_port "$slot")
+    api_port=$(profile_api_port "$slot")
+
+    local dir
+    dir=$(profile_dir "$name")
+    local cfg_status="no config"
+    [[ -f "${dir}/config.yaml" ]] && cfg_status="configured"
+    [[ -f "${dir}/.env" ]] && cfg_status="configured+keys"
+
+    local marker=""
+    [[ "$name" == "$active" ]] && marker=" ★"
+
+    printf "  %-16s %-8s %-12s %-12s %s%s\n" \
+      "$name" "$cfg_status" ":$web_port" ":$api_port" "$dir" "$marker"
+  done < <(profile_list_names)
+
+  if [[ "$found" == "false" ]]; then
+    echo "  (no profiles yet — run: hermes-agent-cloud profile create <name>)"
+  fi
+
+  echo ""
+  echo "  ★ = active profile"
+  echo ""
+}
+
+profile_cmd_use() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    error "Usage: hermes-agent-cloud profile use <name>"
+    exit 1
+  fi
+
+  if ! profile_exists "$name" && [[ "$name" != "default" ]]; then
+    error "Profile '${name}' does not exist. Run: hermes-agent-cloud profile create ${name}"
+    exit 1
+  fi
+
+  profile_set_active "$name"
+  success "Active profile set to: ${name}"
+
+  local slot
+  slot=$(profile_slot "$name")
+  local web_port api_port
+  web_port=$(profile_web_port "$slot")
+  api_port=$(profile_api_port "$slot")
+  echo ""
+  echo "  Web dashboard : http://<your-ip>:${web_port}"
+  echo "  API gateway   : http://<your-ip>:${api_port}"
+  echo ""
+}
+
+profile_cmd_create() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    name=$(gum input --placeholder "profile name (e.g. work, personal)" --prompt "Profile name: ")
+  fi
+
+  if [[ -z "$name" ]]; then
+    error "Profile name is required."
+    exit 1
+  fi
+
+  # Validate name: lowercase, alphanumeric + hyphens
+  if ! [[ "$name" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    error "Profile name must be lowercase alphanumeric with hyphens (e.g. 'work', 'my-profile')."
+    exit 1
+  fi
+
+  if profile_exists "$name"; then
+    warn "Profile '${name}' already exists."
+    gum confirm "Overwrite its API keys?" || exit 0
+  fi
+
+  local dir
+  dir=$(profile_dir "$name")
+  mkdir -p "$dir"
+
+  local slot
+  slot=$(profile_slot "$name")
+  local web_port api_port
+  web_port=$(profile_web_port "$slot")
+  api_port=$(profile_api_port "$slot")
+
+  echo ""
+  gum style --bold --foreground 212 "Creating profile: ${name}"
+  echo ""
+  warn "Ports: web=${web_port}, api=${api_port}"
+  echo ""
+
+  # ── Collect API keys ──────────────────────────────────────────────────────
+  gum style --bold "API Keys  (at least one required)"
+  echo ""
+  local openrouter_key openai_key anthropic_key gemini_key
+  openrouter_key=$(masked_input "OpenRouter API key")
+  openai_key=$(masked_input "OpenAI API key")
+  anthropic_key=$(masked_input "Anthropic (Claude) API key")
+  gemini_key=$(masked_input "Google Gemini API key")
+
+  local key_count
+  key_count=$(count_keys "$openrouter_key" "$openai_key" "$anthropic_key" "$gemini_key")
+  if [[ "$key_count" -eq 0 ]]; then
+    error "At least one API key is required."
+    rm -rf "$dir"
+    exit 1
+  fi
+
+  # ── Write .env ────────────────────────────────────────────────────────────
+  local env_file="${dir}/.env"
+  : > "$env_file"
+  [[ -n "$openrouter_key" ]] && echo "OPENROUTER_API_KEY=${openrouter_key}" >> "$env_file"
+  [[ -n "$openai_key"     ]] && echo "OPENAI_API_KEY=${openai_key}"         >> "$env_file"
+  [[ -n "$anthropic_key"  ]] && echo "ANTHROPIC_API_KEY=${anthropic_key}"   >> "$env_file"
+  [[ -n "$gemini_key"     ]] && echo "GEMINI_API_KEY=${gemini_key}"         >> "$env_file"
+  chmod 600 "$env_file"
+
+  # ── Write config.yaml ─────────────────────────────────────────────────────
+  cat > "${dir}/config.yaml" <<YAML
+terminal:
+  backend: docker
+  container_cpu: 1
+  container_memory: 5120
+  container_disk: 51200
+  container_persistent: true
+
+agent:
+  max_turns: 90
+
+compression:
+  enabled: true
+  threshold: 0.50
+
+display:
+  tool_progress: all
+
+web:
+  enabled: true
+  port: ${web_port}
+YAML
+
+  success "Profile '${name}' created at ${dir}"
+  echo ""
+  echo "  To deploy this profile:  hermes-agent-cloud profile use ${name} && hermes-agent-cloud deploy"
+  echo "  To list all profiles:    hermes-agent-cloud profile list"
+  echo ""
+}
+
+profile_cmd_remove() {
+  local name="${1:-}"
+  if [[ -z "$name" ]]; then
+    error "Usage: hermes-agent-cloud profile remove <name>"
+    exit 1
+  fi
+
+  if [[ "$name" == "default" ]]; then
+    error "Cannot remove the 'default' profile."
+    exit 1
+  fi
+
+  if ! profile_exists "$name"; then
+    error "Profile '${name}' does not exist."
+    exit 1
+  fi
+
+  gum confirm "Remove profile '${name}' and all its config? This cannot be undone." || exit 0
+
+  rm -rf "$(profile_dir "$name")"
+
+  # Remove from slots file
+  local slots_file="${HERMES_DEPLOY_HOME}/profile_slots"
+  if [[ -f "$slots_file" ]]; then
+    sed -i.bak "/^${name}=/d" "$slots_file"
+    rm -f "${slots_file}.bak"
+  fi
+
+  # Reset active if it was this profile
+  local active
+  active=$(profile_get_active)
+  if [[ "$active" == "$name" ]]; then
+    profile_set_active "default"
+    warn "Active profile reset to 'default'."
+  fi
+
+  success "Profile '${name}' removed."
+}
+
+profile_cmd_show() {
+  local name="${1:-$(profile_get_active)}"
+  local dir
+  dir=$(profile_dir "$name")
+
+  echo ""
+  gum style --bold --foreground 212 "Profile: ${name}"
+  echo ""
+
+  local slot
+  slot=$(profile_slot "$name")
+  printf "  %-14s %s\n" "Directory:"  "$dir"
+  printf "  %-14s %s\n" "Web port:"   "$(profile_web_port "$slot")"
+  printf "  %-14s %s\n" "API port:"   "$(profile_api_port "$slot")"
+
+  if [[ -f "${dir}/.env" ]]; then
+    echo ""
+    gum style --bold "API Keys:"
+    while IFS='=' read -r key _; do
+      [[ -z "$key" || "$key" == \#* ]] && continue
+      printf "  ✓  %s\n" "$key"
+    done < "${dir}/.env"
+  else
+    warn "No .env file — run: hermes-agent-cloud profile create ${name}"
+  fi
+
+  if [[ -f "${dir}/config.yaml" ]]; then
+    echo ""
+    gum style --bold "config.yaml:"
+    sed 's/^/    /' "${dir}/config.yaml"
+  fi
+  echo ""
+}

--- a/cli/scripts/bootstrap.sh
+++ b/cli/scripts/bootstrap.sh
@@ -2,17 +2,42 @@
 # bootstrap.sh — Hermes Agent installation and configuration script
 #
 # Runs over SSH after Terraform provisions the VM.
-# Expects ~/.hermes/.env to already exist (written by the CLI via ssh_upload_env).
+# Expects the profile .env to already exist (written by the CLI via ssh_upload_env).
 # Must be run as root (sudo).
+#
+# Usage: bootstrap.sh [--user <ssh-user>] [--profile <profile-name>] [--web-port <port>] [--api-port <port>]
 set -euo pipefail
 
-# ── Constants ──────────────────────────────────────────────────────────────
+# ── Argument parsing ────────────────────────────────────────────────────────
 HERMES_USER="ubuntu"
-HERMES_HOME="/home/$HERMES_USER/.hermes"
+HERMES_PROFILE="default"
+WEB_PORT="9119"
+API_PORT="8080"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user)      HERMES_USER="$2";    shift 2 ;;
+    --profile)   HERMES_PROFILE="$2"; shift 2 ;;
+    --web-port)  WEB_PORT="$2";       shift 2 ;;
+    --api-port)  API_PORT="$2";       shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# ── Constants ──────────────────────────────────────────────────────────────
+# Profiles are stored under ~/.hermes-profiles/<name>/
+# The "default" profile keeps .env at ~/.hermes/.env for backward compatibility.
+HERMES_PROFILES_ROOT="/home/${HERMES_USER}/.hermes-profiles"
+if [[ "$HERMES_PROFILE" == "default" ]]; then
+  HERMES_HOME="/home/$HERMES_USER/.hermes"
+else
+  HERMES_HOME="${HERMES_PROFILES_ROOT}/${HERMES_PROFILE}"
+fi
 HERMES_ENV="$HERMES_HOME/.env"
 HERMES_CONFIG="$HERMES_HOME/config.yaml"
-LOG_FILE="/var/log/hermes-bootstrap.log"
-LOG_TAG="hermes-bootstrap"
+SERVICE_NAME="hermes-${HERMES_PROFILE}"
+LOG_FILE="/var/log/hermes-bootstrap-${HERMES_PROFILE}.log"
+LOG_TAG="hermes-bootstrap[${HERMES_PROFILE}]"
 
 log()  { echo "[$LOG_TAG] $*" | tee -a $LOG_FILE; }
 fail() { echo "[$LOG_TAG] ERROR: $*" | tee -a $LOG_FILE >&2; exit 1; }
@@ -68,14 +93,14 @@ display:
 
 web:
   enabled: true
-  port: 9119
+  port: ${WEB_PORT}
 YAML
 chown -R $HERMES_USER:$HERMES_USER $HERMES_HOME
 log "  Hermes config written to $HERMES_CONFIG"
 
 # ── 4. Register hermes-gateway systemd service ───────────────────────────────
-log "Step 4/4: Registering systemd service"
-cat > /etc/systemd/system/hermes-gateway.service <<EOF
+log "Step 4/4: Registering systemd service (${SERVICE_NAME})"
+cat > /etc/systemd/system/${SERVICE_NAME}.service <<EOF
 [Unit]
 Description=Hermes Agent Gateway
 Documentation=https://hermes-agent.nousresearch.com
@@ -98,8 +123,8 @@ WantedBy=multi-user.target
 EOF
 
 systemctl daemon-reload
-systemctl enable hermes-gateway
-systemctl start hermes-gateway
+systemctl enable "${SERVICE_NAME}"
+systemctl start "${SERVICE_NAME}"
 log "  hermes-gateway service started"
 
-log "Bootstrap complete. Check status: journalctl -u hermes-gateway -f"
+log "Bootstrap complete. Check status: journalctl -u ${SERVICE_NAME} -f"


### PR DESCRIPTION
## Summary

Implements multi-profile support as specified in #12 — allowing users to run multiple isolated Hermes Agent instances on the same VM, each with its own API keys, config, port, and systemd service.

## Changes

### New: `cli/lib/profile.sh`
- `profile create <name>` — interactive wizard to create a named profile (collects API keys, writes `.env` + `config.yaml`, allocates ports)
- `profile list` — table view of all profiles with status, ports, config path, and active marker ★
- `profile use <name>` — switch the active profile
- `profile show [name]` — detailed view of a profile's keys and config
- `profile remove <name>` — delete a profile with confirmation prompt

### Updated: `cli/scripts/bootstrap.sh`
- Accepts `--user`, `--profile`, `--web-port`, `--api-port` arguments
- Registers a per-profile systemd service (`hermes-<name>.service`) instead of the hardcoded `hermes-gateway`
- Writes config.yaml with the correct `web.port` for the profile
- `default` profile stays at `~/.hermes/` for full backward compatibility

### Updated: `cli/hermes-deploy`
- Sources `lib/profile.sh`
- Adds `profile` to the command dispatch table and help text

### Updated: `README.md`
- Full multi-profile documentation section with use cases, commands, port table, and storage layout

## Port Allocation

| Profile   | Web Dashboard | API Gateway |
|-----------|---------------|-------------|
| `default` | `:9119`       | `:8080`     |
| 1st extra | `:9120`       | `:8081`     |
| 2nd extra | `:9121`       | `:8082`     |

## Backward Compatibility

Existing single-instance deployments are fully unaffected — they continue to work as the `default` profile with no changes required.

## Testing

- [ ] `profile create work` prompts for keys and writes correct files
- [ ] `profile list` shows all profiles with correct ports
- [ ] `profile use work` switches active profile
- [ ] `profile remove work` cleans up files and resets active if needed
- [ ] `bootstrap.sh --profile work --user ubuntu --web-port 9120 --api-port 8081` registers `hermes-work.service`
- [ ] Existing deploy without `--profile` still works (default profile)

Closes #12