### PR TITLE
fix(gcp): resolve zone lookup and label casing bugs

### DIFF
--- a/cli/lib/gcp.sh
+++ b/cli/lib/gcp.sh
@@ -35,7 +35,21 @@ gcp_wizard() {
   region_choice=$(choose_one "Select deployment region" "${GCP_REGION_LABELS[@]}")
   REGION="$(echo "$region_choice" | awk '{print $1}')"
   validate_gcp_region "$REGION"
-  local zone="${REGION}-a"
+
+  # Query available zones — not every region has a zone "-a"
+  local available_zones
+  available_zones=$(gcloud compute zones list \
+    --filter="region:${REGION}" \
+    --project "${project_id}" \
+    --format="value(name)" 2>/dev/null | sort)
+
+  if [[ -z "$available_zones" ]]; then
+    error "No zones found for region ${REGION}. Check the region name and project permissions."
+    exit 1
+  fi
+
+  local zone
+  zone=$(echo "$available_zones" | head -1)
 
   # ── Step 2: Machine type ──────────────────────────────────────────────────
   step_header 2 $steps "Machine Type"

--- a/cli/terraform/gcp/main.tf
+++ b/cli/terraform/gcp/main.tf
@@ -36,6 +36,6 @@ resource "google_compute_instance" "hermes" {
   tags = ["hermes-agent"]
 
   labels = {
-    project = "Hermes-Agent-Cloud"
+    project = "hermes-agent-cloud"
   }
 }


### PR DESCRIPTION
                                                                                                                                                                          
   ## Summary                                                                                                                                                                     
                                                                                                                                                                                  
   Two bugs that cause GCP deploys to fail during `terraform apply`.                                                                                                              
                                                                                                                                                                                  
   ## Bug 1: Hardcoded zone suffix `-a`                                                                                                                                           
                                                                                                                                                                                  
   **File:** `cli/lib/gcp.sh`                                                                                                                                                     
                                                                                                                                                                                  
   `gcp_wizard()` hardcodes `zone="${REGION}-a"` but not every GCP region has a zone `-a`. For example, `us-east1` only has zones `b`, `c`, `d`.                                  
                                                                                                                                                                                  
   **Error:**                                                                                                                                                                     
                                                                                                                                                                       
                                                                                                                                                                                  
 Error 404: The resource 'projects/.../zones/us-east1-a' was not found                                                                                                            
                                                                                                                                                                                  
                                                                                                                                                                     
                                                                                                                                                                                  
   **Fix:** Query available zones dynamically via `gcloud compute zones list` and pick the first one.                                                                             
                                                                                                                                                                                  
   ## Bug 2: Uppercase label value                                                                                                                                                
                                                                                                                                                                                  
   **File:** `cli/terraform/gcp/main.tf`                                                                                                                                          
                                                                                                                                                                                  
   The instance label `project = "Hermes-Agent-Cloud"` violates GCP's label format constraints (must be lowercase).                                                               
                                                                                                                                                                                  
   **Error:**                                                                                                                                                                     
                                                                                                                                                                        
                                                                                                                                                                                  
 Label value 'Hermes-Agent-Cloud' violates format constraints                                                                                                                     
                                                                                                                                                                                  
                                                                                                                                                                        
                                                                                                                                                                                  
   **Fix:** Change to `project = "hermes-agent-cloud"`.                                                                                                                           
                                                                                                                                                                                  
   ## Testing                                                                                                                                                                     
                                                                                                                                                                                  
   Deployed to `us-east1-b` on project `hermes-cloud-495109` with these fixes applied — instance created successfully.                                                            
                          