### PR TITLE
fix: Windows compatibility — CRLF, Git Bash guard, WSL2 SSH key permissions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,34 @@
+# Force LF line endings for all shell scripts and text files.
+# This prevents Windows Git from converting LF → CRLF, which breaks bash shebangs
+# and causes "$'\r': command not found" errors on the remote VM.
+
+* text=auto eol=lf
+
+# Explicitly mark shell scripts as LF
+*.sh    text eol=lf
+*.bash  text eol=lf
+
+# Hermes deploy entrypoints (no extension)
+cli/hermes-deploy        text eol=lf
+cli/install.sh           text eol=lf
+
+# Terraform files
+*.tf     text eol=lf
+*.tfvars text eol=lf
+
+# JSON / YAML
+*.json  text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+
+# Markdown
+*.md    text eol=lf
+
+# Binaries — never touch
+*.png   binary
+*.jpg   binary
+*.gif   binary
+*.ico   binary
+*.zip   binary
+*.tar   binary
+*.gz    binary

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,6 +19,34 @@ Built with [Charm's `gum`](https://github.com/charmbracelet/gum) for a fully int
 
 ---
 
+## Windows Support
+
+Hermes Agent Cloud is a Bash-based tool and **requires a POSIX shell environment**.
+
+| Environment | Status | Notes |
+|---|---|---|
+| **WSL2** (Ubuntu) | ✅ Fully supported | Recommended for Windows users |
+| **macOS** | ✅ Fully supported | — |
+| **Linux** | ✅ Fully supported | — |
+| Git Bash / MSYS | ❌ Not supported | Missing `sudo`, `chmod`, Bash 4+ |
+| PowerShell / CMD | ❌ Not supported | Not a POSIX shell |
+
+### Setting up WSL2 (Windows)
+
+1. Open **PowerShell as Administrator** and run:
+   ```powershell
+   wsl --install
+   ```
+2. Restart your PC, then open the **Ubuntu** app from the Start menu.
+3. Inside the WSL2 terminal, run the installer:
+   ```bash
+   curl -sSL https://raw.githubusercontent.com/unrealandychan/Hermes-Agent-Cloud/main/cli/install.sh | bash
+   ```
+
+> **SSH key tip:** Store your cloud SSH private key inside the WSL2 filesystem (`~/keys/mykey.pem`) rather than on the Windows drive (`/mnt/c/...`). Windows NTFS permissions can cause SSH to reject the key with an "unprotected private key file" error even after `chmod 600`.
+
+---
+
 ## Prerequisites
 
 | Tool | Version | Install |

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -18,6 +18,36 @@ RESET='\033[0m'
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
+# ── Windows guard ────────────────────────────────────────────────────────────
+# uname -s on Git Bash returns "MINGW64_NT-*" or "MSYS_NT-*"
+# on Cygwin it returns "CYGWIN_NT-*"
+# We detect all of these and guide the user to WSL2 instead.
+check_windows() {
+  case "$OS" in
+    MINGW*|MSYS*|CYGWIN*)
+      echo ""
+      echo -e "${RED}${BOLD}Windows host detected (Git Bash / MSYS / Cygwin)${RESET}"
+      echo ""
+      echo -e "  Hermes Agent Cloud requires a POSIX shell environment with:"
+      echo -e "  • ${BOLD}sudo${RESET}   (not available in Git Bash)"
+      echo -e "  • ${BOLD}ssh${RESET}    (OpenSSH with Unix permission enforcement)"
+      echo -e "  • ${BOLD}bash 4+${RESET} with proper LF line endings"
+      echo ""
+      echo -e "  ${YELLOW}${BOLD}Recommended: use WSL2 (Windows Subsystem for Linux)${RESET}"
+      echo ""
+      echo -e "  1. Open PowerShell as Administrator and run:"
+      echo -e "     ${BOLD}wsl --install${RESET}"
+      echo -e "  2. Restart your PC, then open the Ubuntu app."
+      echo -e "  3. Inside WSL2, re-run the installer:"
+      echo -e "     ${BOLD}curl -sSL https://raw.githubusercontent.com/unrealandychan/Hermes-Agent-Cloud/main/cli/install.sh | bash${RESET}"
+      echo ""
+      echo -e "  WSL2 docs: ${DIM}https://learn.microsoft.com/windows/wsl/install${RESET}"
+      echo ""
+      exit 1
+      ;;
+  esac
+}
+
 banner() {
   echo ""
   echo -e "${BOLD}Hermes Agent Cloud installer — v${HERMES_DEPLOY_VERSION}${RESET}"
@@ -301,6 +331,7 @@ install_hermes_deploy() {
 # ── Main ────────────────────────────────────────────────────────────────────
 main() {
   banner
+  check_windows
   require_sudo
 
   install_bash

--- a/cli/lib/ssh.sh
+++ b/cli/lib/ssh.sh
@@ -1,6 +1,35 @@
 #!/usr/bin/env bash
 # ssh.sh — SSH helpers for post-Terraform installation
 
+# ── Fix SSH key permissions (cross-platform) ─────────────────────────────────
+# On Linux/macOS, chmod 600 is sufficient.
+# On WSL2, keys stored on the Windows filesystem (/mnt/c/...) have NTFS
+# permissions that override Unix chmod. We detect this and use icacls via
+# cmd.exe to lock down the key, then warn the user if that also fails.
+_fix_key_permissions() {
+  local key="$1"
+
+  # If the key is on a Windows-mounted path (WSL2), use icacls
+  if [[ "$key" == /mnt/* ]] && command -v cmd.exe &>/dev/null 2>&1; then
+    # Convert /mnt/c/Users/... → C:\Users\...
+    local win_path
+    win_path="$(wslpath -w "$key" 2>/dev/null || true)"
+    if [[ -n "$win_path" ]]; then
+      local win_user
+      win_user="$(cmd.exe /c "echo %USERNAME%" 2>/dev/null | tr -d '\r\n' || true)"
+      if [[ -n "$win_user" ]]; then
+        cmd.exe /c "icacls \"${win_path}\" /inheritance:r /grant:r \"${win_user}:R\" >NUL 2>&1" || true
+        return
+      fi
+    fi
+    warn "Could not fix key permissions via icacls. If SSH fails, move your key file out of /mnt/c/ (e.g. to ~/keys/) or run: chmod 600 \"$key\""
+    return
+  fi
+
+  # Standard Unix path
+  chmod 600 "$key" 2>/dev/null || warn "Could not chmod 600 $key — SSH may refuse the key"
+}
+
 # ─── Wait for SSH to become available ───────────────────────────────────────
 # ssh_wait <ip> <user> <key_path> [timeout_seconds]
 ssh_wait() {
@@ -13,6 +42,7 @@ ssh_wait() {
 
   # Expand tilde
   key="${key/#\~/$HOME}"
+  _fix_key_permissions "$key"
 
   warn "Waiting for SSH on ${ip} (up to ${timeout}s)..."
   while (( elapsed < timeout )); do
@@ -45,6 +75,7 @@ ssh_upload_env() {
   local gemini_key="$7"
 
   key="${key/#\~/$HOME}"
+  _fix_key_permissions "$key"
 
   # Build .env content — only include lines for non-empty keys.
   # printf is used instead of echo to avoid shell expansion of the values.
@@ -77,6 +108,7 @@ ssh_install() {
   local bootstrap="$4"
 
   key="${key/#\~/$HOME}"
+  _fix_key_permissions "$key"
 
   echo ""
   gum style --foreground 212 --bold "  ─── Installing Hermes Agent via SSH ────────────────────────"
@@ -104,6 +136,7 @@ ssh_update_key() {
   local new_value="$5"
 
   key="${key/#\~/$HOME}"
+  _fix_key_permissions "$key"
 
   warn "Updating ${var_name} on ${user}@${ip} ..."
   # Pass the new value via stdin; only the safe alphanumeric var_name is


### PR DESCRIPTION
## Problem

Users on Windows encountered silent failures and cryptic errors when trying to use Hermes Agent Cloud.

## Root Causes & Fixes

### 1. 🔴 Missing `.gitattributes` — CRLF line endings break bash
**Symptom:** `$'\r': command not found` or shebang `#!/usr/bin/env bash\r` not found on the remote VM.

**Fix:** Added `.gitattributes` enforcing `eol=lf` for all `.sh`, `.tf`, `.yaml`, `.json`, and entrypoint files. Windows Git no longer converts LF → CRLF on clone.

---

### 2. 🔴 `install.sh` silently fails on Git Bash / MSYS
**Symptom:** `uname -s` returns `MINGW64_NT-*` — the `case` statement falls through to `die "Unsupported OS"` after printing confusing intermediate errors. `sudo` is also unavailable in Git Bash.

**Fix:** Added `check_windows()` called at the top of `main()`. Detects `MINGW*`, `MSYS*`, `CYGWIN*` and immediately prints a clear error with step-by-step WSL2 setup instructions.

---

### 3. 🟡 SSH key permission failures on WSL2 (`/mnt/c/...` keys)
**Symptom:** `chmod 600` on NTFS-mounted paths has no effect. SSH refuses the key with "Permissions for 'key.pem' are too open."

**Fix:** Added `_fix_key_permissions()` helper in `ssh.sh`, called in all four SSH functions (`ssh_wait`, `ssh_upload_env`, `ssh_install`, `ssh_update_key`). On WSL2 with a `/mnt/c/...` path, uses `icacls` via `cmd.exe` to set NTFS permissions. Falls back to `chmod 600` on standard Unix paths.

---

### 4. 📖 README — Windows Support section
Added a Windows Support section with:
- Compatibility table (WSL2 ✅ / Git Bash ❌ / PowerShell ❌)
- WSL2 setup steps
- SSH key storage tip (keep keys in WSL2 filesystem, not `/mnt/c/...`)

## Files Changed
- `.gitattributes` — new
- `cli/install.sh` — Windows guard + WSL2 instructions
- `cli/lib/ssh.sh` — `_fix_key_permissions()` helper
- `cli/README.md` — Windows Support section
